### PR TITLE
Replace colon in report name with underscore

### DIFF
--- a/tcfl/report.py
+++ b/tcfl/report.py
@@ -372,7 +372,7 @@ class file_c(report_c):
     #:
     #: >>> tcfl.report.file_c.templates['MYTEMPLATE'] = dict(
     #: >>>    #:  name = 'report.j2.txt',
-    #: >>>    #:  output_file_name = 'report-%(runid)s:%(tc_hash)s.txt',
+    #: >>>    #:  output_file_name = 'report-%(runid)s_%(tc_hash)s.txt',
     #: >>>    #:  report_pass = False,
     #: >>>    #:  report_skip = False,
     #: >>>    #:  report_error = True,
@@ -492,7 +492,7 @@ class file_c(report_c):
     templates = {
         "text" : dict(
             name = 'report.j2.txt',
-            output_file_name = 'report-%(runid)s:%(tc_hash)s.txt',
+            output_file_name = 'report-%(runid)s_%(tc_hash)s.txt',
             report_pass = False,
             report_skip = False,
             report_error = True,
@@ -501,7 +501,7 @@ class file_c(report_c):
         ),
         "junit" : dict(
             name = 'junit.j2.xml',
-            output_file_name = 'junit-%(runid)s:%(tc_hash)s.xml',
+            output_file_name = 'junit-%(runid)s_%(tc_hash)s.xml',
             report_pass = False,
             report_skip = False,
             report_error = False,


### PR DESCRIPTION
The colon (:) in report name, e.g. report-XXXX:YYYYYY.txt
is causing a lot of unnecessary problems. For example, it is
not possible to open it in gedit, it is being misinterpreted
as separators by some other programs. Sometimes program
treats colon as a special character with special meaning,
and steps such as escaping, putting it in quotes or
substitution with unicode representation is needed to
get inform the program to not treat it as special
character.

The use of colon is not really compulsory here, so substitute
it with underscore.

Signed-off-by: Ooi, Cinly <cinly.ooi@intel.com>