### PR TITLE
tcfl.pos: fix rsync_extra default value to be "", not None

### DIFF
--- a/tcfl/pos.py
+++ b/tcfl/pos.py
@@ -1254,7 +1254,7 @@ def deploy_path(ic, target, _kws, cache = True):
     """
     source_path = getattr(target, "deploy_path_src", None)
     dst_path = getattr(target, "deploy_path_dest", "/")
-    rsync_extra = getattr(target, "deploy_rsync_extra", None)
+    rsync_extra = getattr(target, "deploy_rsync_extra", "")
     if source_path == None:
         target.report_info("not deploying local path because "
                            "*target.deploy_path_src is missing or None ",


### PR DESCRIPTION
This change will fix the issue where file failed to deploy with the following error message:

`D @local deploy output: rsync: link_stat "/home/z/t/tcf.git/None" failed: No such file or directory (2)
D @local deploy output: rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1196) [sender=3.1.2]`