### PR TITLE
ttbd/pos/tcf-image-setup.sh: fix su login without password

### DIFF
--- a/ttbd/pos/tcf-image-setup.sh
+++ b/ttbd/pos/tcf-image-setup.sh
@@ -446,7 +446,7 @@ done
 
 for file in etc/pam.d/common-auth usr/share/pam.d/su; do
     [ -r $destdir/$file ] || continue
-    grep -q "pam_unix.so.*nullok" $destdir/$file || continue
+    grep -q "pam_unix.so.*nullok" $destdir/$file && continue
     # Some distros configure PAM to disallow passwordless root; we
     # change that so automation doesn't have to work through so many
     # hoops


### PR DESCRIPTION
Only continue if we can find "pam_unix.so.*nullok"
in $destdir/$file. If not, then we will proceed to add
nullok.

Signed-off-by: Md Ismail, Zakiah <zakiah.md.ismail@intel.com>