### PR TITLE
ttbl.apc: add support for snmpv3 authentication

### DIFF
--- a/ttbd/ttbl/apc.py
+++ b/ttbd/ttbl/apc.py
@@ -7,6 +7,7 @@
 # pylint: disable = missing-docstring
 
 import sys
+from pathlib import Path
 
 import ttbl.power
 try:
@@ -56,7 +57,13 @@ class pc(ttbl.power.impl_c):
 
     **System setup**
 
+    2 different options available:
+    SNMPv1 without authentication.
+    SNMPv3 with authentication data read from a config file.
+
     - configure an IP address (static, DHCP) to the APC PDU
+
+    SNMPv1 configuration:
 
     - in the web configuration:
 
@@ -64,9 +71,36 @@ class pc(ttbl.power.impl_c):
        - Administration > Network > SNMPv1 > access control: set the
          community name *private* to *Access Type* *write +*
 
-      This driver currently supports no port, username or passwords --
-      it is recommended to place these units in a private protected
-      network until such support is added.
+      When using SNMPv1 without authentication it is recommended to place
+      these units in a private protected network.
+
+    SNMPv3 configuration:
+
+    - in the web configuration:
+
+       - Administration/Configuration > Network > SNMPv3 > access: enable
+       - Administration/Configuration > Network > SNMPv3 > user profiles: select user
+         in this example the username is 'admin'
+       - Administration/Configuration > Network > SNMPv3 > user profiles > admin:
+         configure the Authentication and Privacy passphrases. In this example
+         we're using 'Authentication Protocol' MD5 and 'Privacy Protocol' DES.
+
+    - SNMPv3 config file example:
+
+      Add a config file for each PDU on the machine where this python module is installed to:
+      /etc/snmp/hosts/<hostname>.conf
+      This is the same location Linux 'net-snmp-utils' tools would look for
+      configuration data for <hostname> snmp controlled device.
+
+      Example configuration file contents:
+
+      defVersion 3
+      defSecurityName admin
+      defSecurityLevel AuthPriv
+      defAuthType MD5
+      defPrivType DES
+      defAuthPassphrase <Authentication passphrase you configured to PDU>
+      defPrivPassphrase <Privacy passphrase you configured to PDU>
 
 
     **Finding OIDs, etc**
@@ -117,7 +151,26 @@ class pc(ttbl.power.impl_c):
 
     def __init__(self, hostname, outlet, oid = None, **kwargs):
         ttbl.power.impl_c.__init__(self, **kwargs)
-        self._community = pysnmp.entity.rfc3413.oneliner.cmdgen.CommunityData('private')
+
+        # if SNMP config file corresponding to the hostname exists read the contents to a dictionary
+        # and use the user authentication information provided to access the pdu with SNMPv3 methods
+        # else use SNMPv1 with no authentication information.
+        cfgdata = {}
+        cfgfilepath = Path("/etc/snmp/hosts/" + hostname + ".conf")
+        if cfgfilepath.is_file():
+            with open(cfgfilepath) as file:
+                for line in file:
+                    if line.strip():
+                        if not line.startswith("#"):
+                            (key, value) = line.split()
+                            cfgdata[key] = value
+
+            self._authdata = pysnmp.entity.rfc3413.oneliner.cmdgen.UsmUserData(cfgdata['defSecurityName'],
+                                                                               cfgdata['defAuthPassphrase'],
+                                                                               cfgdata['defPrivPassphrase'])
+        else:
+            self._authdata = pysnmp.entity.rfc3413.oneliner.cmdgen.CommunityData('private')
+
         self._destination = pysnmp.entity.rfc3413.oneliner.cmdgen.UdpTransportTarget((hostname, 161))
         self.outlets = self._outlet_count()
         self.host = hostname
@@ -133,7 +186,7 @@ class pc(ttbl.power.impl_c):
     def _outlet_count(self):
         ( _errors, _status, _index, varl ) = \
             pysnmp.entity.rfc3413.oneliner.cmdgen.CommandGenerator().getCmd(
-                self._community, self._destination,
+                self._authdata, self._destination,
                 (self.oid + self.table_size)
             )
         # response is something like:
@@ -169,7 +222,7 @@ class pc(ttbl.power.impl_c):
         # (None, 0, 0, [ObjectType(ObjectIdentity(ObjectName('1.3.6.1.4.1.318.1.1.4.4.2.1.3.1')), Integer(2))])
         ( errors, status, _index, varl ) = \
             pysnmp.entity.rfc3413.oneliner.cmdgen.CommandGenerator().getCmd(
-                self._community, self._destination,
+                self._authdata, self._destination,
                 (self.oid + self.pdu_outlet_ctl)
             )
         if errors != None:
@@ -188,7 +241,7 @@ class pc(ttbl.power.impl_c):
     def on(self, target, component):
         ( errors, status, _index, _varl ) = \
             pysnmp.entity.rfc3413.oneliner.cmdgen.CommandGenerator().setCmd(
-                self._community, self._destination,
+                self._authdata, self._destination,
                 (
                     self.oid + self.pdu_outlet_ctl,
                     pysnmp.proto.rfc1902.Integer(1) # 2 - turn on
@@ -201,7 +254,7 @@ class pc(ttbl.power.impl_c):
     def off(self, target, component):
         ( errors, status, _index, _varl ) = \
             pysnmp.entity.rfc3413.oneliner.cmdgen.CommandGenerator().setCmd(
-                self._community, self._destination,
+                self._authdata, self._destination,
                 (
                     self.oid + self.pdu_outlet_ctl,
                     pysnmp.proto.rfc1902.Integer(2) # 2 - turn off


### PR DESCRIPTION
Add support for SNMPv3 password authentication with SNMPv3
authentication data read from configuration files.

Signed-off-by: Juha Haapakorpi <juha.haapakorpi@linux.intel.com>
