### PR TITLE
ui/static&templates: fixed small typo that was bothering me since I noticed it.

### DIFF
--- a/ttbd/ui/static/css/buttons.css
+++ b/ttbd/ui/static/css/buttons.css
@@ -42,12 +42,12 @@ button:active {
     transition-duration: 0.1s;
 }
 
-.secundary {
+.secondary {
     background-color: skyblue;
     color: white;
 }
 
-.secundary:hover {
+.secondary:hover {
     background-color: royalblue;
     text-decoration: underline;
     color: white;

--- a/ttbd/ui/templates/allocation.html
+++ b/ttbd/ui/templates/allocation.html
@@ -55,7 +55,7 @@ ttbd's /ttb-v2/ui/allocation.
           <div class='subsection'>
             <div class="tooltip">
 
-                <button class='secundary' onclick='js_alloc_remove("{{allocid}}")'>
+                <button class='secondary' onclick='js_alloc_remove("{{allocid}}")'>
                     remove myself as guest
                 </button>
 

--- a/ttbd/ui/templates/custom_fields.html
+++ b/ttbd/ui/templates/custom_fields.html
@@ -29,7 +29,7 @@
         </span>
       </div>
       <div class = "tooltip">
-        <button class='secundary' onclick='js_uncheck_all_checkboxes("ui_preferred_fields_for_targets_table"); $(".message").empty();'>Clean Selection</button>
+        <button class='secondary' onclick='js_uncheck_all_checkboxes("ui_preferred_fields_for_targets_table"); $(".message").empty();'>Clean Selection</button>
           <span class = "tooltiptext">
             Clear the selection on the tables. Uncheck all checkboxes.
             <p>

--- a/ttbd/ui/templates/target.html
+++ b/ttbd/ui/templates/target.html
@@ -140,7 +140,7 @@ $ tcf ls -vv {{ targetid}}</code> </pre></p>
       #}
       {% if state.user_is_admin == True and state.user_is_guest == False and state.user != state.owner %}
           <div class = "tooltip">
-            <button class='secundary'
+            <button class='secondary'
                     onclick='js_alloc_guest_add("{{state.alloc}}","{{state.user}}"); window.location.reload();'>
                 add myself as a guest
            </button>

--- a/ttbd/ui/templates/targets.html
+++ b/ttbd/ui/templates/targets.html
@@ -43,7 +43,7 @@ no permissions, use the <i>report issue</i> link above</p>
         </span>
       </div>
       <div class = "tooltip" style='margin-left: auto'>
-        <button class='secundary' onclick="toggle_class('table-cell-inventory-keys')">Toggle Keys</button>
+        <button class='secondary' onclick="toggle_class('table-cell-inventory-keys')">Toggle Keys</button>
         <span class = "tooltiptext">
            Toggle the visibility of the keys in the table, if you see no change, there are not keys in the table.
         </span>


### PR DESCRIPTION
Class was misspelled `secundary` instead of `secondary`