### PR TITLE
WebUI: add widget to add, remove and download SSL certificates

### DIFF
--- a/ttbd/ttbl/ui.py
+++ b/ttbd/ttbl/ui.py
@@ -552,6 +552,12 @@ def _target_tunnel_collect(target, inventory, state):
 
 
 
+def _target_certs_collect(target, calling_user: str, state: dict):
+    if hasattr(target, 'certs'):
+        r = target.certs.get_certificate(target, calling_user, None, None, None)
+        state['certs'] = sorted(r.get("client_certificates", []))
+
+
 
 @bp.route('/target/<targetid>', methods = ['GET'])
 @flask_login.login_required
@@ -660,6 +666,8 @@ def _target(targetid):
     consoles = dict(inventory.get('interfaces', {}).get('console', {}))
 
     tunnels = _target_tunnel_collect(target, inventory, state)
+    _target_certs_collect(target, calling_user.get_id(), state)
+
     return flask.render_template(
         'target.html',
         targetid = targetid,

--- a/ttbd/ui/static/js/main.js
+++ b/ttbd/ui/static/js/main.js
@@ -380,6 +380,88 @@ async function js_tunnel_remove(targetid, port, protocol, ip_addr) {
 
 
 
+/*
+* Add a cert from form data
+*
+* @param {targetid} str -> target id
+*
+* @param {input_field_id} str -> where to get the cert name from
+*
+* return {void}
+*/
+async function js_certs_add_from_input_field(targetid, input_field_id) {
+
+    $('.diagnostics').empty();
+    $('#loading').append(
+        '<label>adding certificate: </label><progress id="progress-bar" aria-label="Content loading…"></progress></div>' +
+        '<br>'
+    );
+    let data = new URLSearchParams();
+
+    let name_el = document.getElementById(input_field_id);
+    if (name_el == null) {
+	$('#loading').empty();
+	$('#loading').append(
+            '<b><label style="color: red;">ERROR: name not specified</label></b>'
+	);
+        return
+    }
+
+    data.append('name', name_el.value);
+    let r = await fetch('/ttb-v2/targets/' + targetid + '/certs/certificate', {
+        method: 'PUT',
+	body: data,
+    });
+
+    let error_message = await r.text();
+    if (common_error_check(r, error_message)) {
+        return;
+    }
+
+    $('#loading').empty();
+    $('#loading').append(
+        '<b><label style="color: green;">SUCCESS</label></b>'
+    );
+
+    window.location.reload();
+}
+
+
+
+/*
+* Remove a certificate from an allocation
+*
+* @param {targetid} str -> target id
+*
+* @param {name} str -> cert to remove
+*
+* return {void}
+*/
+async function js_cert_remove(targetid, name) {
+
+    $('.diagnostics').empty();
+
+    let data = new URLSearchParams();
+    data.append('name', name);
+    let r = await fetch('/ttb-v2/targets/' + targetid + '/certs/certificate', {
+        method: 'DELETE',
+	body: data,
+    });
+
+    let error_message = await r.text();
+    if (common_error_check(r, error_message)) {
+        return
+    }
+
+    $('#loading').empty();
+    $('#loading').append(
+        '<b><label style="color: green;">SUCCESS</label></b>'
+    );
+
+    window.location.reload()
+}
+
+
 
 /*
 * make a flashing call given a version and an image type

--- a/ttbd/ui/templates/target.html
+++ b/ttbd/ui/templates/target.html
@@ -560,6 +560,7 @@ $ tcf ls -vv {{ targetid}}</code> </pre></p>
     </div>
 
     {% include 'widget-target-tunnels.html' %}
+    {% include 'widget-target-certs.html' %}
 
 </div>
 

--- a/ttbd/ui/templates/widget-target-certs.html
+++ b/ttbd/ui/templates/widget-target-certs.html
@@ -1,0 +1,111 @@
+<!-- this is start of file ui/widget-target-certificates.html -->
+
+<div class='status'>
+  {% if tunnels is none %}
+    <h4 class='info info-grey'>certificates: not supported</h4>
+  {% else %}
+    <h3 class='info info-grey'>
+      <div class = "tooltip">
+        certificates
+        <span class = "tooltiptext">
+          Manage any number of SSL certificate/private-key pairs tied
+          a Root Certificate Authority that is valid only as long as
+          the allocation is valid. These can be later used to create
+          tunnels, or secure anything in an allocation-specific way,
+          so they cannot be reused later.
+        </span>
+      </div>
+    </h3>
+    <table class='display'>
+      <thead>
+        <th align="left" colspan = 2>Name</th>
+        <th align="left">Actions</th>
+      </thead>
+
+      <!-- certs is just a list of names -->
+      {% if not state.certs  %}
+      <tr>
+        {# FIXME: need to figure out max column size and tooltip out #}
+        {# the label if too big #}
+        <td colspan = 4 style = 'color: gray;'>
+          no certificates have yet been defined
+        </td>
+      </tr>
+      {% endif %}
+      {% for name in ( state.certs if state.certs else [] ) %}
+      <tr>
+        <td>{{ name }}</td>
+        <td align = "right">
+          <div class = "tooltip">
+            <a href = "/ttb-v2/targets/{{ targetid }}/store/file?file_path=certificates_client/{{ name }}.key"
+               download = 'cert-{{ state.alloc }}-{{ targetid }}-{{ name }}.key'
+               style = "text-decoration:none">⚿</a>
+            <span class = "tooltiptext">
+              Download the SSL private key
+              <p>
+                On the command line, you can use:
+                <pre><code class="language-bash">$ tcf certs-get {{targetid }} --save {{ name }}</code></pre>
+              </p>
+            </span>
+          </div>
+          <div class = "tooltip">
+            <a href = "/ttb-v2/targets/{{ targetid }}/store/file?file_path=certificates_client/{{ name }}.cert"
+               download = 'cert-{{ state.alloc }}-{{ targetid }}-{{ name }}.cert'
+               style = "text-decoration:none">🖂</a>
+            <span class = "tooltiptext">
+              Download the SSL certificate
+              <p>
+                On the command line, you can use:
+                <pre><code class="language-bash">$ tcf certs-get {{targetid }} --save {{ name }}</code></pre>
+              </p>
+            </span>
+          </div>
+        </td>
+
+        <td>
+          <div class = "tooltip">
+            <button class = 'warning' onclick = 'js_cert_remove("{{targetid}}", "{{ name }}");'>-</button>
+            <span class = "tooltiptext">
+              Remove this SSL certificate/private-key pair
+              <p>
+                On the command line, you can use:
+                <pre><code class="language-bash">$ tcf certs-rm {{ targetid }} {{ name }}</code></pre>
+              </p>
+            </span>
+          </div>
+        </td>
+      </tr>
+      {% endfor %}
+
+      <!-- Add row -->
+      <tr>
+        <td colspan = 2 style='color: gray;'>
+          <div class = "tooltip">
+            <input type = "text" size = 17 id = "input_field_id_cert_add"
+                   placeholder = "enter certificate name"
+                   required>
+            <span class = "tooltiptext">
+              Simple name to identify the SSL certificate/private-key pair
+            </span>
+          </div>
+        </td>
+
+        <td style='color: gray;'>
+          <div class = "tooltip">
+            <button class = 'primary' onclick = 'js_certs_add_from_input_field("{{targetid}}", "input_field_id_cert_add")'>+</button>
+            <span class = "tooltiptext">
+              Create a new SSL certificate/private-key pair
+              <p>
+                On the command line, you can use:
+                <pre><code class="language-bash">$ tcf certs-get {{ targetid }} [--save] NAME</code></pre>
+              </p>
+            </span>
+          </div>
+        </td>
+
+      </tr>
+
+    </table>
+  {% endif %}
+</div>		<!-- certificates -->
+<!-- this is end of file ui/widget-target-certificates.html -->


### PR DESCRIPTION
Adds buttons to add/remove, functionality to list and download private keys and certificate files for SSL key/cert pairs associated to the unique Root CA associated to the allocation ID.

![image](https://github.com/user-attachments/assets/0825b1f7-a658-4e72-bbea-1b43b76f123b)
