### PR TITLE
WebUI: make multi-value dialog more compact

### DIFF
--- a/ttbd/ui/templates/targets.html
+++ b/ttbd/ui/templates/targets.html
@@ -86,20 +86,25 @@ no permissions, use the <i>report issue</i> link above</p>
                     {{entry}}
                     <br>
                {% endfor %}
-                    <br>
                     <dialog class='dialog-inventory-details' id='{{targetid}}-{{columns[field]}}'>
-                      <button autofocus onclick='close_dialog_element_by_id("{{targetid}}-{{columns[field]}}")'>Close</button>
-                        <br>
-                        <h2>{{targetid}}</h2>
-                        <h3>{{field}}</h3>
-                        <hr>
-                       {% for key, entry in columns[field]['all_entries'] %}
-                            <small class='table-cell-inventory-keys'>{{key}}:</small>
-                            <br>
-                            {{entry}}
-                            <br>
-                            <hr>
-                       {% endfor %}
+                      {# details for fields with multiple cells #}
+                      <h2>
+                        <button autofocus onclick='close_dialog_element_by_id("{{targetid}}-{{columns[field]}}")'>╳</button>{{targetid}}: all values for fields <i>{{field}}</i></h2>
+                      <table class='display'>
+                        <thead>
+                          <th>Field</th>
+                          <th>Value</th>
+                        </thead>
+                        <tbody>
+                          {% for key, entry in columns[field]['all_entries'] %}
+                          <tr>
+                            {# use fixed font for field names, so visually they allign #}
+                            <td class='table-cell-inventory-keys'><code>{{ key }}</code></td>
+                            <td>{{ entry }}</td>
+                          </tr>
+                        </tbody>
+                        {% endfor %}
+                      </table>
                     </dialog>
                     <button class='show_more_info_inside_table' onclick='open_dialog_element_by_id("{{targetid}}-{{columns[field]}}")'>more...</button>
                 </td>


### PR DESCRIPTION
Current representation of the multi-value dialog for the inventory was taking a lot of vertical space, when we have plenty of horizontal available.

This is the dialog that pops when a cell in the inventory has too much data (because it is an aggregation of multiple values).

Reformatted to be a simple table with the keys and values side by side; header in a single line with a close button represented by an X.

New looks like:
![image](https://github.com/user-attachments/assets/59cfdffa-22f8-44ae-9804-cdf3002d907e)

Old looked like:
![image](https://github.com/user-attachments/assets/535f372f-1ad2-4dd8-aab7-2554efb78ae2)
